### PR TITLE
Autoprovision and Authenticator support with detailed examples

### DIFF
--- a/SampleAuth.php
+++ b/SampleAuth.php
@@ -105,10 +105,10 @@ class SampleAuthPlugin extends MantisPlugin  {
 		* custom Authenticator Page for user. This is called, when the user entered both username and password in the standard MantisBT login flow
 		* username and password in $_POST
 		*
-		* Please NOTE: if you don't do any filtering - e.g. e-mail - than this will be the only Auth Plugin besides the built-in! Stacking is not (yes) supported
+		* Please NOTE: if you don't do any filtering - e.g. e-mail - than this will be the only Auth Plugin besides the built-in! Stacking is not (yet) supported
 		*
 		*/
-		$t_flags->setAuthenticatorPage( helper_url_combine( plugin_page( 'login', /* redirect */ true ), ( !empty($t_username) ? 'username=' . $t_username : '' ) ) );
+		$t_flags->setAuthenticatorPage( helper_url_combine( plugin_page( 'login', /* redirect */ true ), ( !empty($t_username) ? 'username=' . urlencode($t_username) : '' ) ) );
 		/*
 		*
 		* custom Logout Page for user.

--- a/SampleAuth.php
+++ b/SampleAuth.php
@@ -15,9 +15,9 @@ class SampleAuthPlugin extends MantisPlugin  {
 		$this->description = plugin_lang_get( 'description' );
 		$this->page = '';
 
-		$this->version = '0.1';
+		$this->version = '0.2';
 		$this->requires = array(
-			'MantisCore' => '2.3.0-dev',
+			'MantisCore' => '2.14.0-dev',
 		);
 
 		$this->author = 'MantisBT Team';
@@ -37,16 +37,23 @@ class SampleAuthPlugin extends MantisPlugin  {
 		return $t_hooks;
 	}
 
+	function config() {
+	    return array(
+		    # set to 'true', if the plugin can do autoprovisioning - otherwise only "known" users will be able to log in
+		    'autoprovision' => true,
+		    # sets the access level configured by autoprov; defaults to system configures default access level
+		    'default_access_level' => config_get( 'default_new_account_access_level' )
+		);
+	}
+
 	function auth_user_flags( $p_event_name, $p_args ) {
 		# Don't access DB if db_is_connected() is false.
-
 		$t_username = $p_args['username'];
 
 		$t_user_id = $p_args['user_id'];
 
-		# If user is unknown, don't handle authentication for it, since this plugin doesn't do
-		# auto-provisioning
-		if( !$t_user_id ) {
+		# If user is unknown and autoprovision is not set, than don't handle authentication for it
+		if( !$t_user_id && ! plugin_config_get( 'autoprovision' ) ) {
 			return null;
 		}
 
@@ -55,14 +62,29 @@ class SampleAuthPlugin extends MantisPlugin  {
 			return null;
 		}
 
-		$t_access_level = user_get_access_level( $t_user_id, ALL_PROJECTS );
+		if( $t_user_id ) {
+		    $t_access_level = user_get_access_level( $t_user_id, ALL_PROJECTS );
 
-		# Have administrators use default login flow
-		if( $t_access_level >= ADMINISTRATOR ) {
+		    # Have administrators use default login flow
+		    if( $t_access_level >= ADMINISTRATOR ) {
 			return null;
+		    }
 		}
 
-		# for everybody else use the custom authentication
+		/*
+		*
+		* add any filter parameters here
+		*
+		* e.g. if you want the plugin to handle usernames only which contain '@':
+		*
+		* if ( ! preg_match('/^.*@.*$/',$t_username) ) {
+		* 	return null;
+		* }
+		*
+		* or to use this custom authenticateion for everybody else:
+		*
+		*/
+
 		$t_flags = new AuthFlags();
 
 		# Passwords managed externally for all users
@@ -71,9 +93,28 @@ class SampleAuthPlugin extends MantisPlugin  {
 
 		# No one can use standard auth mechanism
 
-		# Override Login page and Logout Redirect
-		$t_flags->setCredentialsPage( helper_url_combine( plugin_page( 'login', /* redirect */ true ), 'username=' . $t_username ) );
-		$t_flags->setLogoutRedirectPage( plugin_page( 'logout', /* redirect */ true ) );
+		# Override Credentials, Authenticator page and Logout Redirect - see 'pages' subdirectory
+		/*
+		*
+		* custom Credentials Page for user. This is displayed after the user did input his username (and the username is known to Mantis or plugin is autoprov capable)
+		*
+		*/
+		//$t_flags->setCredentialsPage( helper_url_combine( plugin_page( 'credentials', /* redirect */ true ), 'username=' . $t_username ) );
+		/*
+		*
+		* custom Authenticator Page for user. This is called, when the user entered both username and password in the standard MantisBT login flow
+		* username and password in $_POST
+		*
+		* Please NOTE: if you don't do any filtering - e.g. e-mail - than this will be the only Auth Plugin besides the built-in! Stacking is not (yes) supported
+		*
+		*/
+		$t_flags->setAuthenticatorPage( helper_url_combine( plugin_page( 'login', /* redirect */ true ), ( !empty($t_username) ? 'username=' . $t_username : '' ) ) );
+		/*
+		*
+		* custom Logout Page for user.
+		*
+		*/
+		//$t_flags->setLogoutRedirectPage( plugin_page( 'logout', /* redirect */ true ) );
 
 		# No long term session for identity provider to be able to kick users out.
 		$t_flags->setPermSessionEnabled( false );

--- a/core/CustomAuthPlugin.php
+++ b/core/CustomAuthPlugin.php
@@ -21,7 +21,16 @@
 /**
  * Class for dealing with custom authentication requests
  *
- * Class is written for demonstration purposes
+ *
+ * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+ * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+ * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+ *
+ * Class is written for demonstration purposes ONLY!!!
+ *
+ * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+ * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+ * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  *
  * @copyright Tamas Dajka 2018
  * @author Tamas Dajka <viper@vipernet.hu>
@@ -56,7 +65,7 @@ class CustomAuthPlugin {
 	 * - false on login failure
 	 * - username on login success
 	 */
-	function login($username,$password) {
+	function login( $username, $password ) {
 	    /*
 	    *
 	    * Check access/auth in remote system
@@ -92,18 +101,25 @@ class CustomAuthPlugin {
 		    *
 		    */      
 
-		    $user_data = $this->get_user_data($username);
+		    $user_data = $this->get_user_data( $username );
 
 		    /*
 		    * create user, but with empty e-mail => prevent mantis from sending signup e-mail
-		    * we set a strong random password 
+		    * we set a strong random password
+		    *
+		    * To get this work, you either have to set $g_allow_blank_email = ON, or change the value here on-the-fly (don't forget to set it back)
+		    *
 		    */
+		    $original_g_allow_blank_email = config_get( 'allow_blank_email' );
+		    config_set_global( '$allow_blank_email', 'ON' );
 		    user_create( $username, auth_generate_random_password(24), '',  $user_data['access_level'], false, true, $user_data['realname'] );
+		    config_set_global('$allow_blank_email', $original_g_allow_blank_email );
+
 		    /*
 		    * Set user e-mail
 		    */
-		    if( ! is_blank($user_data['email']) && email_is_valid($user_data['email']) && ( $t_user_id = user_get_id_by_name($username) ) ) {
-			user_set_field($t_user_id,'email',$user_data['email']);
+		    if( !is_blank( $user_data['email'] ) && email_is_valid( $user_data['email'] ) && ( $t_user_id = user_get_id_by_name( $username ) ) ) {
+			user_set_field( $t_user_id,'email', $user_data['email'] );
 		    }
 		}
 	    }
@@ -126,7 +142,7 @@ class CustomAuthPlugin {
 	 *
 	 * @return: array()
 	 */
-	function get_user_data($username='') {
+	function get_user_data( $username = '' ) {
 	    if ( empty($username) ) {
 		return array();
 	    }
@@ -143,8 +159,8 @@ class CustomAuthPlugin {
 	 * @params: username, password
 	 * @return: bool
 	 */
-	function auth($username,$password) {
-	    if ( empty($username) || empty($password) ) {
+	function auth( $username, $password ) {
+	    if ( empty( $username ) || empty( $password ) ) {
 		return false;
 	    }
 	

--- a/core/CustomAuthPlugin.php
+++ b/core/CustomAuthPlugin.php
@@ -111,9 +111,9 @@ class CustomAuthPlugin {
 		    *
 		    */
 		    $original_g_allow_blank_email = config_get( 'allow_blank_email' );
-		    config_set_global( '$allow_blank_email', 'ON' );
+		    config_set_global( '$allow_blank_email', ON );
 		    user_create( $username, auth_generate_random_password(24), '',  $user_data['access_level'], false, true, $user_data['realname'] );
-		    config_set_global('$allow_blank_email', $original_g_allow_blank_email );
+		    config_set_global( 'allow_blank_email', $original_g_allow_blank_email );
 
 		    /*
 		    * Set user e-mail

--- a/core/CustomAuthPlugin.php
+++ b/core/CustomAuthPlugin.php
@@ -71,7 +71,7 @@ class CustomAuthPlugin {
 	    * Check access/auth in remote system
 	    *
 	    */
-	    if ( ! $this->auth($username,$password) ) {
+	    if ( !$this->auth($username,$password) ) {
 		return false;
 	    }
 	
@@ -101,7 +101,7 @@ class CustomAuthPlugin {
 		    *
 		    */      
 
-		    $user_data = $this->get_user_data( $username );
+		    $t_user_data = $this->get_user_data( $username );
 
 		    /*
 		    * create user, but with empty e-mail => prevent mantis from sending signup e-mail
@@ -112,14 +112,14 @@ class CustomAuthPlugin {
 		    */
 		    $original_g_allow_blank_email = config_get( 'allow_blank_email' );
 		    config_set_global( 'allow_blank_email', ON );
-		    user_create( $username, auth_generate_random_password(24), '',  $user_data['access_level'], false, true, $user_data['realname'] );
+		    user_create( $username, auth_generate_random_password(24), '',  $t_user_data['access_level'], false, true, $t_user_data['realname'] );
 		    config_set_global( 'allow_blank_email', $original_g_allow_blank_email );
 
 		    /*
 		    * Set user e-mail
 		    */
-		    if( !is_blank( $user_data['email'] ) && email_is_valid( $user_data['email'] ) && ( $t_user_id = user_get_id_by_name( $username ) ) ) {
-			user_set_field( $t_user_id,'email', $user_data['email'] );
+		    if( !is_blank( $t_user_data['email'] ) && email_is_valid( $t_user_data['email'] ) && ( $t_user_id = user_get_id_by_name( $username ) ) ) {
+			user_set_field( $t_user_id,'email', $t_user_data['email'] );
 		    }
 		}
 	    }
@@ -173,6 +173,7 @@ class CustomAuthPlugin {
 	    # comment this out for testing or write your own
 	    return false;
 	
+	    /* example authentication */
 	    if( $username == 'john.doe' && $password == 'Abc.123' ) {
 		return true;
 	    } else {

--- a/core/CustomAuthPlugin.php
+++ b/core/CustomAuthPlugin.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * MantisBT - A PHP based bugtracking system
+ *
+ * MantisBT is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * MantisBT is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @copyright Copyright 2002  MantisBT Team - mantisbt-dev@lists.sourceforge.net
+ */
+
+/**
+ * Class for dealing with custom authentication requests
+ *
+ * Class is written for demonstration purposes
+ *
+ * @copyright Tamas Dajka 2018
+ * @author Tamas Dajka <viper@vipernet.hu>
+ * @link http://www.mantisbt.org
+ * @package MantisBT
+ * @subpackage classes
+ * @plugin SampleAuth
+ */
+
+/*
+*
+* User API is needed for user auto provision
+*
+*/
+require_api( 'user_api.php' );
+require_api( 'email_api.php' );
+
+class CustomAuthPlugin {
+
+	/**
+	 * Constructor
+	 */
+	function __construct() {
+	    # spaceholder
+	}
+	
+	/**
+	 * login
+	 *
+	 * @params: username, password
+	 * @return:
+	 * - false on login failure
+	 * - username on login success
+	 */
+	function login($username,$password) {
+	    /*
+	    *
+	    * Check access/auth in remote system
+	    *
+	    */
+	    if ( ! $this->auth($username,$password) ) {
+		return false;
+	    }
+	
+	    /*
+	    *
+	    * Should we autoprovision the user?
+	    *
+	    */
+	    if( plugin_config_get( 'autoprovision' ) ) {
+		/*
+		* Check if user exists, probably needs customization
+		*/
+		if( ! user_get_id_by_name($username) ) {
+		    /*
+		    * data needed for autorpovision:
+		    * - username
+		    * - password
+		    *
+		    * Optional params:
+		    *
+		    * - email
+		    * - access_level (null)
+		    * - protected (false)
+		    * - enabled (true)
+		    * - realname
+		    * - admin_name
+		    *
+		    */      
+
+		    $user_data = $this->get_user_data($username);
+
+		    /*
+		    * create user, but with empty e-mail => prevent mantis from sending signup e-mail
+		    * we set a strong random password 
+		    */
+		    user_create( $username, auth_generate_random_password(24), '',  $user_data['access_level'], false, true, $user_data['realname'] );
+		    /*
+		    * Set user e-mail
+		    */
+		    if( ! is_blank($user_data['email']) && email_is_valid($user_data['email']) && ( $t_user_id = user_get_id_by_name($username) ) ) {
+			user_set_field($t_user_id,'email',$user_data['email']);
+		    }
+		}
+	    }
+	    
+	    return $username;
+	}
+	
+	/**
+	 * logout
+	 *
+	 * @return: bool
+	 */
+	function logout() {
+	    # spaceholder
+	    return true;
+	}
+	
+	/**
+	 * collects user data from auth system
+	 *
+	 * @return: array()
+	 */
+	function get_user_data($username='') {
+	    if ( empty($username) ) {
+		return array();
+	    }
+	    
+	    /*
+	    * dummy data for now, access_level 25 is REPORTER -> see <ROOT>/core/constant_inc.php
+	    */
+	    return array( 'username' => $username, 'email' => 'john.doe@gmail.com', 'access_level' => config_get( 'default_new_account_access_level' ), 'realname' => 'John Doe' );
+	}
+	
+	/**
+	 * Auth validity check
+	 *
+	 * @params: username, password
+	 * @return: bool
+	 */
+	function auth($username,$password) {
+	    if ( empty($username) || empty($password) ) {
+		return false;
+	    }
+	
+	    /*
+	    * We should check for external auth here
+	    *
+	    * dummy return for now
+	    */
+	
+	    # comment this out for testing or write your own
+	    return false;
+	
+	    if( $username == 'john.doe' && $password == 'Abc.123' ) {
+		return true;
+	    } else {
+		return false;
+	    }
+	}
+}

--- a/core/CustomAuthPlugin.php
+++ b/core/CustomAuthPlugin.php
@@ -111,7 +111,7 @@ class CustomAuthPlugin {
 		    *
 		    */
 		    $original_g_allow_blank_email = config_get( 'allow_blank_email' );
-		    config_set_global( '$allow_blank_email', ON );
+		    config_set_global( 'allow_blank_email', ON );
 		    user_create( $username, auth_generate_random_password(24), '',  $user_data['access_level'], false, true, $user_data['realname'] );
 		    config_set_global( 'allow_blank_email', $original_g_allow_blank_email );
 

--- a/pages/credentials.php
+++ b/pages/credentials.php
@@ -6,36 +6,18 @@ require_once( 'core.php' );
 require_api( 'authentication_api.php' );
 require_api( 'user_api.php' );
 
-$f_username = gpc_get_string( 'username', '' );
-$f_password = gpc_get_string( 'password', '' );
+$f_username = gpc_get( 'username' );
 $f_reauthenticate = gpc_get_bool( 'reauthenticate', false );
 $f_return = gpc_get_string( 'return', config_get( 'default_home_page' ) );
 
 $t_return = string_url( string_sanitize_url( $f_return ) );
 
-$f_username = auth_prepare_username( $f_username );
-$f_password = auth_prepare_password( $f_password );
-
 /*
 *
-* Log in the user with the custom class
-*
-* class should return username/false upon successful/failed login
+* Set up and call the external authenticator with the username provided
+* (password is not known this time - makeing use of SSO possible
 *
 */
-
-plugin_require_api( 'core/CustomAuthPlugin.php' );
-$cap = new CustomAuthPlugin();
-if ( ( $f_username = $cap->login($f_username,$f_password) ) ) {
-    /*
-    *
-    * All set, good to go
-    *
-    * if you want to assign the user to project(s) based on a criteria
-    * than this is the right palce. Don't forget to check if it's already assigned
-    *
-    */
-}
 
 $t_user_id = is_blank( $f_username ) ? false : user_get_id_by_name( $f_username );
 

--- a/pages/login.php
+++ b/pages/login.php
@@ -32,7 +32,7 @@ if ( ( $f_username = $cap->login($f_username,$f_password) ) ) {
     * All set, good to go
     *
     * if you want to assign the user to project(s) based on a criteria
-    * than this is the right palce. Don't forget to check if it's already assigned
+    * than this is the right place. Don't forget to check if it's already assigned
     *
     */
 }

--- a/pages/logout.php
+++ b/pages/logout.php
@@ -6,6 +6,15 @@ require_once( 'core.php' );
 require_api( 'authentication_api.php' );
 
 # User is already logged out from Mantis
-# TODO: logout from external identity provider
+# TODO by the plugin: logout from external identity provider if necessary or redirect to custom page
 
+/**
+*
+* plugin_require_api( 'core/CustomAuthPlugin.php' );
+* $cap = new CustomAuthPlugin();
+* $cap->logout();
+*
+*/
+
+# default redirect to Mantis login page
 print_header_redirect( auth_login_page(), true, false );

--- a/readme.md
+++ b/readme.md
@@ -1,14 +1,12 @@
 # SampleAuth Plugin
 
-#
-# Autoprov and authenticator support added by Tamas Dajka (viper@vipernet.hu)
-#
-
 This is a sample authentication plugin showing how a MantisBT authentication plugin can implement its own authentication and control authentication related flags on a per user basis.
+
+Autoprov and authenticator support added by Tamas Dajka (viper@vipernet.hu)
 
 The authentication mechanism implemented by this plugin works as follows:
 - If user is administrator, use standard authentication.
-- If user is not registered in the db, user standard behavior.
+- If user is not registered in the db, use standard behavior; or if autoprovision is set then provision the user
 - Otherwise, auto-signin the user without a password.
 
 Users that are auto-signed in, can't manage or use passwords that are stored in the MantisBT database.
@@ -51,19 +49,30 @@ If you want to use multiple auth backends, than you'll have to do filtering. You
 - use authenticator_page and setup the login there
 - setup filtering in class and have multiple instances of the class (not yet tested)
 
-1) Set login_page
-- if you set the login page, than the user will be validated after Mantis runs login.php. It's difficult to properly set up, due to Mantis logic
-- only works, if the user is known to Mantis. Autoprovisioning is not possible.
+1. Set login_page
+   - if you set the login page, than the user will be validated after Mantis runs login.php. It's difficult to properly set up, due to Mantis logic
+   - only works, if the user is known to Mantis. Autoprovisioning is not possible.
 
-2) Set credential_page
-- you'll be able to use SSO or orher 3rd party auth provider
-- this is called, once Mantis asks for the username
-- you'll have to ask for the user's password
-- will only work, if the user is known to Mantis OR you set up and turn on autoprovisioning!
+2. Set credential_page
+   - you'll be able to use SSO or orher 3rd party auth provider
+   - this is called, once Mantis asks for the username
+   - you'll have to ask for the user's password
+   - will only work, if the user is known to Mantis OR you set up and turn on autoprovisioning!
 
-3) Set authenticator_page
-- you'll make use of Mantis built in login mech (username/password page)
-- you'll have to use your own method to authenticate the user, with the possibility of autoprovision it (and assign to projects, etc)
+3. Set authenticator_page
+   - you'll make use of Mantis built in login mech (username/password page)
+   - you'll have to use your own method to authenticate the user, with the possibility of autoprovision it (and assign to projects, etc)
+
+
+## About Mantis login flow
+
+The following describes the standard login flow of Mantis; if user is not logged in, then login_page is shown to aquire the username.
+
+- Login Page to aquire username
+- Username is sent to Login Password page
+  - if CredentialsPage authflag is set, then user is redirected to it _(please note, user must be known to Mantis or user autoprovision must be configured and enabled)_
+  - if AuthenticatorPage authflag is set then the password is aquired, but all data is POST-ed to the page provided
+- Username and Password is POST-ed to login.php, which validates the data. If you set LoginPage authflag, than the user will be redirected to it, if her/his credentials (password) were not valid _(NOTE that user must be known to Mantis for this to work!)_
 
 ## Screenshots
 

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,9 @@
 # SampleAuth Plugin
 
+#
+# Autoprov and authenticator support added by Tamas Dajka (viper@vipernet.hu)
+#
+
 This is a sample authentication plugin showing how a MantisBT authentication plugin can implement its own authentication and control authentication related flags on a per user basis.
 
 The authentication mechanism implemented by this plugin works as follows:
@@ -11,14 +15,19 @@ Users that are auto-signed in, can't manage or use passwords that are stored in 
 
 The plugin can be easily modified to redirect to an identity provider and validate the token returned or validate a username and password against a database or LDAP.
 
+## Config parameters
+- `autoprovision` set to 'true', if the plugin can do autoprovisioning - otherwise only "known" users will be able to log in
+- `default_access_level` sets the access level configured by autoprov; defaults to system configures default access level
+
 ## Authentication Flags
 The authentication flags events enables the plugin to control MantisBT core authentication behavior on a per user basis.
 Plugins can also show their own pages to accept credentials from the user.
 
 - `password_managed_elsewhere_message` message to show in MantisBT UI to indicate that password is managed externally.  If left blank or not set, the default message will be used.
 - `can_use_standard_login` true then standard password form and validation is used, false: otherwise.
-- `login_page` Custom login page to use.
-- `credential_apge` The page to show to ask the user for their credential.
+- `login_page` Custom login page to use. Will be called, if Mantis fails to authenticate the user against it's own mechanisms
+- `credential_page` The page to show to ask the user for their credential.
+- `authenticator_page` The page to validate the username AND password
 - `logout_page` Custom logout page to use.
 - `logout_redirect_page` Page to redirect to after user is logged out.
 - `session_lifetime` Default session lifetime in seconds or 0 for browser session.
@@ -36,6 +45,26 @@ the user typed in the first login page that asks for username.
 If plugin doesn't want to handle a specific user, it should return null.  Otherwise, it should
 return the `AuthFlags` with the overriden settings.
 
+## Options/Setup possibilities
+
+If you want to use multiple auth backends, than you'll have to do filtering. You'll have two possibilities to do so:
+- use authenticator_page and setup the login there
+- setup filtering in class and have multiple instances of the class (not yet tested)
+
+1) Set login_page
+- if you set the login page, than the user will be validated after Mantis runs login.php. It's difficult to properly set up, due to Mantis logic
+- only works, if the user is known to Mantis. Autoprovisioning is not possible.
+
+2) Set credential_page
+- you'll be able to use SSO or orher 3rd party auth provider
+- this is called, once Mantis asks for the username
+- you'll have to ask for the user's password
+- will only work, if the user is known to Mantis OR you set up and turn on autoprovisioning!
+
+3) Set authenticator_page
+- you'll make use of Mantis built in login mech (username/password page)
+- you'll have to use your own method to authenticate the user, with the possibility of autoprovision it (and assign to projects, etc)
+
 ## Screenshots
 
 Native Login Page for Username
@@ -51,4 +80,4 @@ User My Account Page
 ![Profile Page](doc/sample_auth_no_password_change.png "Profile Page")
 
 ## Dependencies
-MantisBT v2.3.0-dev once auth plugin support is added.
+MantisBT v2.14.0-dev once authenticator and autoprovision support is added.


### PR DESCRIPTION
I made some changes to the plugin to be able to support autoprovision and to be able to integrate it with a bit more into Mantis' auth flow. Some changes in Mantis Core is also necessary (separate pull).
A newly added class gives insight on how can one build a custom auth module. Pages are a bit rewritten, to make a better example on the usage. README is also extended to give a bit more insight on the concept.